### PR TITLE
Allowed 'x or not y' condition. Credit goes to @tehhowch

### DIFF
--- a/source/LocationFilter.h
+++ b/source/LocationFilter.h
@@ -23,9 +23,9 @@ class Government;
 class Planet;
 class Ship;
 class System;
-
-
-
+	
+	
+	
 // This class represents a set of constraints on a randomly chosen planet or
 // system. For example, it can require that the planet used for a mission have
 // a certain attribute or be owned by a certain government, or be a certain
@@ -51,6 +51,7 @@ private:
 	std::set<const Planet *> planets;
 	// It must have at least one attribute from each set in this list:
 	std::list<std::set<std::string>> attributes;
+	
 	// The system must satisfy these conditions:
 	std::set<const System *> systems;
 	std::set<const Government *> governments;


### PR DESCRIPTION
Also using the '!' prefix for the attribute/government blacklists. I've removed "attributes blacklist" list because I didn't need it anymore (Everything goes into attributes/government now).