### PR TITLE
Make fine scaling apply to cargo as well as installed outfits

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -551,21 +551,29 @@ int64_t CargoHold::Value(const System *system) const
 // so bad that it warrants a death sentence.
 int CargoHold::IllegalCargoFine() const
 {
+	int fine = 0;
 	int worst = 0;
 	// Carrying an illegal outfit is only half as bad as having it equipped.
 	for(const auto &it : outfits)
 	{
-		int fine = it.first->Get("illegal");
-		if(fine < 0)
-			return fine;
-		worst = max(worst, fine / 2);
+		if(it.second)
+		{
+			if(it.first->Get("atrocity") > 0.)
+				return -1;
+			fine += it.second * it.first->Get("illegal");
+
+			worst = max(worst, fine / 2);
+		}
 	}
 	
 	for(const auto &it : missionCargo)
 	{
-		int fine = it.first->IllegalCargoFine();
-		if(fine < 0)
-			return fine;
+		if(it.first->IllegalCargoFine() < 0)
+			return -1;
+		if(it.second)
+		{
+			fine += it.second * it.first->IllegalCargoFine();
+		}
 		worst = max(worst, fine);
 	}
 	return worst;


### PR DESCRIPTION
* If you buy an outfit to cargo, you will have to pay half as much as you would if you simply installed the outfit
* Interference is an all-or-nothing deal when having your cargo scanned, like the original. Except you will have to pay fines for each outfit.
* Mission cargo will have their 'illegal cargo fine' applied for each unit of illegal cargo aboard your ship