### PR TITLE
'Illegal' attribute now takes an optional argument

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -552,17 +552,16 @@ int64_t CargoHold::Value(const System *system) const
 int CargoHold::IllegalCargoFine() const
 {
 	int fine = 0;
-	int worst = 0;
 	// Carrying an illegal outfit is only half as bad as having it equipped.
 	for(const auto &it : outfits)
 	{
+		fine += it.first->IllegalCargoFine();
 		if(it.second)
 		{
 			if(it.first->Get("atrocity") > 0.)
 				return -1;
-			fine += it.second * it.first->Get("illegal");
+			fine += ((it.second - 1) * (it.first->IllegalCargoFine() * it.first->MultiFineMultiplier()));
 
-			worst = max(worst, fine / 2);
 		}
 	}
 	
@@ -574,7 +573,7 @@ int CargoHold::IllegalCargoFine() const
 		{
 			fine += it.second * it.first->IllegalCargoFine();
 		}
-		worst = max(worst, fine);
 	}
-	return worst;
+	fine /= 2;
+	return fine;
 }

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -83,6 +83,18 @@ void Outfit::Load(const DataNode &node)
 			for(const DataNode &grand : child)
 				licenses.push_back(grand.Token(0));
 		}
+		else if(child.Token(0) == "illegal" && child.Size() >= 2)
+		{
+			if(child.Size() == 2)
+			{
+				illegalCargoFine = child.Value(1);
+			}
+			else
+			{
+				illegalCargoFine = child.Value(1);
+				multiFineMultiplier = child.Value(2);
+			}
+		}
 		else if(child.Size() >= 2)
 			attributes[child.Token(0)] = child.Value(1);
 		else
@@ -250,4 +262,18 @@ const map<const Effect *, int> &Outfit::AfterburnerEffects() const
 const Sprite *Outfit::FlotsamSprite() const
 {
 	return flotsamSprite;
+}
+
+
+
+const int64_t Outfit::IllegalCargoFine() const
+{
+	return illegalCargoFine;
+}
+
+
+
+const double Outfit::MultiFineMultiplier() const
+{
+	return multiFineMultiplier;
 }

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -49,6 +49,11 @@ public:
 	const std::string &Category() const;
 	const std::string &Description() const;
 	int64_t Cost() const;
+	
+	// Get the amount of credits you will be fined if you are caught carrying this outfit
+	const int64_t IllegalCargoFine() const;
+	// Get the multiplier for additional fines if you are caught carrying more than one of this outfit
+	const double MultiFineMultiplier() const;
 	// Get the licenses needed to buy or operate this ship.
 	const std::vector<std::string> &Licenses() const;
 	// Get the image to display in the outfitter when buying this item.
@@ -84,6 +89,8 @@ private:
 	std::string description;
 	const Sprite *thumbnail = nullptr;
 	int64_t cost = 0;
+	int64_t illegalCargoFine = 0;
+	double multiFineMultiplier = 0.;
 	// Licenses needed to purchase this item.
 	std::vector<std::string> licenses;
 	


### PR DESCRIPTION
* Now, if you are carrying multiple illegal outfits, you will be charged the first argument as a fine, then for the other outfits of the same type, you will be charged (second argument * first argument) credits.
* If the first argument is 0, the second argument will have no effect.
* * Example: If you have 3 illegal outfits with "illegal 1000000 0.2", and you get caught, you will be charged 1,400,000 credits. (1M for the first outfit, then 1M * 0.2, i.e. 200,000 credits for the other two)