### PR TITLE
Minor change to prevent double-fining for mission cargo

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -571,7 +571,7 @@ int CargoHold::IllegalCargoFine() const
 			return -1;
 		if(it.second)
 		{
-			fine += it.second * it.first->IllegalCargoFine();
+			fine += (it.second - 1) * it.first->IllegalCargoFine();
 		}
 	}
 	fine /= 2;


### PR DESCRIPTION
Just makes sure that you don't get double-charged for your first mission cargo item if you get caught.