### PR TITLE
Allow events to freeze the player's reputation

### DIFF
--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -58,6 +58,8 @@ void Government::Load(const DataNode &node)
 			color = Color(child.Value(1), child.Value(2), child.Value(3));
 		else if(child.Token(0) == "player reputation" && child.Size() >= 2)
 			initialPlayerReputation = child.Value(1);
+		else if(child.Token(0) == "unwavering" && child.Size() >= 2)
+			repLocked = (child.Value(1) > 0);
 		else if(child.Token(0) == "attitude toward")
 		{
 			for(const DataNode &grand : child)
@@ -311,4 +313,11 @@ void Government::AddReputation(double value) const
 void Government::SetReputation(double value) const
 {
 	GameData::GetPolitics().SetReputation(this, value);
+}
+
+
+
+bool Government::IsReputationLocked() const
+{
+	    return repLocked;
 }

--- a/source/Government.h
+++ b/source/Government.h
@@ -75,6 +75,8 @@ public:
 	// it is null, there are no pirate raids.
 	const Fleet *RaidFleet() const;
 	
+	bool IsReputationLocked() const;
+	
 	// Check if, according to the politics stored by GameData, this government is
 	// an enemy of the given government right now.
 	bool IsEnemy(const Government *other) const;
@@ -121,6 +123,7 @@ private:
 	const Phrase *hostileDisabledHail = nullptr;
 	std::string language;
 	const Fleet *raidFleet = nullptr;
+	bool repLocked = false;
 };
 
 

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -110,7 +110,8 @@ void Politics::Offend(const Government *gov, int eventType, int count)
 			if(eventType & ShipEvent::ATROCITY)
 				reputationWith[other] = min(0., reputationWith[other]);
 			
-			reputationWith[other] -= penalty;
+			if(!other->IsReputationLocked() || (eventType & ShipEvent::ATROCITY))
+				reputationWith[other] -= penalty;
 		}
 	}
 }


### PR DESCRIPTION
This PR allows events to freeze the player's reputation with a given government