### PR TITLE
Allow modders to override default crew attack/defense values

### DIFF
--- a/source/CaptureOdds.cpp
+++ b/source/CaptureOdds.cpp
@@ -169,7 +169,7 @@ vector<double> CaptureOdds::Power(const Ship &ship, bool isDefender)
 	
 	// Check for any outfits that assist with attacking or defending:
 	const string attribute = (isDefender ? "capture defense" : "capture attack");
-	const double crewPower = (isDefender ? 2. : 1.);
+	const double crewPower = (isDefender ? ship.GetGovernment()->CrewDefense() : ship.GetGovernment()->CrewAttack());
 	
 	// Each crew member can wield one weapon. They use the most powerful ones
 	// that can be wielded by the remaining crew.

--- a/source/CaptureOdds.h
+++ b/source/CaptureOdds.h
@@ -14,8 +14,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #define CAPTURE_ODDS_H_
 
 #include <vector>
+#include "Government.h"
 
 class Ship;
+class Government;
 
 
 

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -58,6 +58,14 @@ void Government::Load(const DataNode &node)
 			color = Color(child.Value(1), child.Value(2), child.Value(3));
 		else if(child.Token(0) == "player reputation" && child.Size() >= 2)
 			initialPlayerReputation = child.Value(1);
+		else if(child.Token(0) == "crew attack" && child.Size() >= 2)
+		{
+			crewAttack = child.Value(1);
+		}
+		else if(child.Token(0) == "crew defense" && child.Size() >= 2)
+		{
+			crewDefense = child.Value(1);
+		}
 		else if(child.Token(0) == "attitude toward")
 		{
 			for(const DataNode &grand : child)
@@ -312,3 +320,18 @@ void Government::SetReputation(double value) const
 {
 	GameData::GetPolitics().SetReputation(this, value);
 }
+
+
+
+int64_t Government::CrewAttack() const
+{
+	return crewAttack;
+}
+
+
+
+int64_t Government::CrewDefense() const
+{
+	return crewDefense
+}
+

--- a/source/Government.h
+++ b/source/Government.h
@@ -48,6 +48,7 @@ public:
 	int GetSwizzle() const;
 	// Get the color to use for displaying this government on the map.
 	const Color &GetColor() const;
+	bool IsKnown() const;
 	
 	// Get the government's initial disposition toward other governments or
 	// toward the player.
@@ -102,6 +103,10 @@ public:
 	void AddReputation(double value) const;
 	void SetReputation(double value) const;
 	
+	// Get the government's crew attack/defense values
+	int64_t CrewAttack() const;
+	int64_t CrewDefense() const;
+	
 	
 private:
 	unsigned id;
@@ -121,6 +126,8 @@ private:
 	const Phrase *hostileDisabledHail = nullptr;
 	std::string language;
 	const Fleet *raidFleet = nullptr;
+	int64_t crewAttack = 1;
+	int64_t crewDefense = 2;
 };
 
 


### PR DESCRIPTION
This PR will allow modders to specify specific values for crew attack and defense values in a boarding action, rather than the default 1 for attacking and 2 for defending. This is useful for one who wants to make an alien government whose ships are easier or harder to capture than normal.