### PR TITLE
Allow events to modify a fleet's personality without having to replace the personality's definition

### DIFF
--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -48,6 +48,8 @@ void Fleet::Load(const DataNode &node)
 		// clearing the rest of the existing definition.
 		bool add = (key == "add" && hasValue && child.Token(1) == "variant");
 		bool remove = (key == "remove" && hasValue && child.Token(1) == "variant");
+		bool addPersonality = (key == "add" && hasValue && child.Token(1) == "personality");
+		bool removePersonality = (key == "remove" && hasValue && child.Token(1) == "personality");
 		
 		if(key == "government" && hasValue)
 			government = GameData::Governments().Get(child.Token(1));
@@ -63,8 +65,12 @@ void Fleet::Load(const DataNode &node)
 			for(int i = 1; i < child.Size(); ++i)
 				commodities.push_back(child.Token(i));
 		}
+		else if(addPersonality)
+			personality.Load(child, false, false);
+		else if(removePersonality)
+			personality.Load(child, false, true);
 		else if(key == "personality")
-			personality.Load(child);
+			personality.Load(child, true, false);
 		else if(key == "variant" || add)
 		{
 			if(resetVariants && !add)

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -84,7 +84,7 @@ void NPC::Load(const DataNode &node)
 		else if(child.Token(0) == "government" && child.Size() >= 2)
 			government = GameData::Governments().Get(child.Token(1));
 		else if(child.Token(0) == "personality")
-			personality.Load(child);
+			personality.Load(child, true, false);
 		else if(child.Token(0) == "dialog")
 		{
 			for(int i = 1; i < child.Size(); ++i)

--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -92,11 +92,17 @@ Personality::Personality()
 
 
 
-void Personality::Load(const DataNode &node)
+void Personality::Load(const DataNode &node, bool reset, bool remove)
 {
-	flags = 0;
+	if(reset)
+		flags = 0;
 	for(int i = 1; i < node.Size(); ++i)
-		Parse(node.Token(i));
+	{
+		if(node.Token(i) == "personality")
+			continue;
+		Parse(node.Token(i), remove);
+	}
+	
 	
 	for(const DataNode &child : node)
 	{
@@ -105,7 +111,11 @@ void Personality::Load(const DataNode &node)
 		else
 		{
 			for(int i = 0; i < child.Size(); ++i)
-				Parse(child.Token(i));
+			{
+				if(child.Token(i) == "personality")
+					continue;
+				Parse(child.Token(i), remove);
+			}
 		}
 	}
 }
@@ -351,9 +361,14 @@ Personality Personality::Defender()
 
 
 
-void Personality::Parse(const string &token)
+void Personality::Parse(const string &token, bool remove)
 {
 	auto it = TOKEN.find(token);
 	if(it != TOKEN.end())
-		flags |= it->second;
+	{
+		if(remove)
+			flags &= ~it->second;
+		else
+			flags |= it->second;
+	}
 }

--- a/source/Personality.h
+++ b/source/Personality.h
@@ -31,7 +31,7 @@ class Personality {
 public:
 	Personality();
 	
-	void Load(const DataNode &node);
+	void Load(const DataNode &node, bool reset, bool remove);
 	void Save(DataWriter &out) const;
 	
 	// Who a ship decides to attack:
@@ -80,7 +80,7 @@ public:
 	
 	
 private:
-	void Parse(const std::string &token);
+	void Parse(const std::string &token, bool remove);
 	
 	
 private:


### PR DESCRIPTION
This PR allows you to use `add personality` and `remove personality` to add or remove individual personality flags from a fleet. 