### PR TITLE
Switch 'changes' variable

### DIFF
--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -66,8 +66,9 @@ void Fleet::Load(const DataNode &node)
 		}
 		else if(changePersonality)
 		{
-			Personality changes;
+			Personality changes = Personality(0.);
 			changes.Load(child);
+			
 			if(key == "add")
 				personality += changes;
 			else

--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -92,10 +92,18 @@ Personality::Personality()
 
 
 
+Personality::Personality(double confusionMult)
+	: flags(DISABLES), aimMultiplier(1.)
+{
+	confusionMultiplier = confusionMult;
+}
+
+
+
 Personality &Personality::operator+=(const Personality &rhs)
 {
 	flags |= rhs.flags;
-	confusionMultiplier = rhs.confusionMultiplier;
+	confusionMultiplier += rhs.confusionMultiplier;
 	return *this;
 }
 
@@ -104,7 +112,7 @@ Personality &Personality::operator+=(const Personality &rhs)
 Personality &Personality::operator-=(const Personality &rhs)
 {
 	flags &= ~(rhs.flags);
-	confusionMultiplier = rhs.confusionMultiplier;
+	confusionMultiplier -= rhs.confusionMultiplier;
 	return *this;
 }
 

--- a/source/Personality.h
+++ b/source/Personality.h
@@ -30,6 +30,7 @@ class DataWriter;
 class Personality {
 public:
 	Personality();
+	Personality(double confusionMult);
 	
 	// Operators:
 	Personality &operator+=(const Personality &rhs);


### PR DESCRIPTION
I switched the 'changes' temporary Personality to use an alternate constructor so adding and removing confusion isn't so unpredictable.