### PR TITLE
Removed Skybound declaration

### DIFF
--- a/source/Personality.h
+++ b/source/Personality.h
@@ -58,7 +58,6 @@ public:
 	bool IsFleeing() const;
 	bool IsDerelict() const;
 	bool IsUninterested() const;
-	bool IsSkybound() const;
 	
 	// Non-combat goals:
 	bool IsSurveillance() const;


### PR DESCRIPTION
It was removed from the cpp, but not from the .h file.