### PR TITLE
Implement "detects" weapon modifier

### DIFF
--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -40,6 +40,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 			isSafe = true;
 		else if(key == "phasing")
 			isPhasing = true;
+		else if(key == "detects")
+			hitsCloakedTargets = true;
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping weapon attribute with no value specified:");
 		else if(key == "sprite")

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -93,8 +93,10 @@ public:
 	// A "safe" weapon hits only hostile ships (even if it has a blast radius).
 	// A "phasing" weapon hits only its intended target; it passes through
 	// everything else, including asteroids.
+	// A weapon that "detects" can hit cloaked ships as well as targetable ones.
 	bool IsSafe() const;
 	bool IsPhasing() const;
+	bool HitsCloakedTargets() const;
 	
 	// These values include all submunitions:
 	double ShieldDamage() const;
@@ -141,6 +143,7 @@ private:
 	bool isStreamed = false;
 	bool isSafe = false;
 	bool isPhasing = false;
+	bool hitsCloakedTargets = false;
 	
 	// Attributes.
 	int lifetime = 0;
@@ -236,6 +239,7 @@ inline double Weapon::HitForce() const { return hitForce; }
 
 inline bool Weapon::IsSafe() const { return isSafe; }
 inline bool Weapon::IsPhasing() const { return isPhasing; }
+inline bool Weapon::HitsCloakedTargets() const { return hitsCloakedTargets; }
 
 inline double Weapon::ShieldDamage() const { return TotalDamage(SHIELD_DAMAGE); }
 inline double Weapon::HullDamage() const { return TotalDamage(HULL_DAMAGE); }


### PR DESCRIPTION
Weapons that "detect" can hit cloaked ships as well as targetable ones. I've tested it and it seems to work.