### PR TITLE
Use total crew instead of required crew

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -356,9 +356,9 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command)
 					break;
 				
 				if(Random::Real() * total >= yourPower)
-					you->AddCrew(-1);
+					you->AddCrew(-1, false);
 				else
-					victim->AddCrew(-1);
+					victim->AddCrew(-1, false);
 			}
 			
 			// Report how many casualties each side suffered.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2302,6 +2302,13 @@ int Ship::Crew() const
 
 
 
+int Ship::TotalCrew() const
+{
+	return totalCrew;
+}
+
+
+
 int Ship::RequiredCrew() const
 {
 	if(attributes.Get("automaton"))
@@ -2313,9 +2320,11 @@ int Ship::RequiredCrew() const
 
 
 
-void Ship::AddCrew(int count)
+void Ship::AddCrew(int count, bool addTotal)
 {
 	crew = min<int>(crew + count, attributes.Get("bunks"));
+	if(addTotal)
+		totalCrew = min<int>(crew + count, attributes.Get("bunks"));
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -263,8 +263,9 @@ public:
 	
 	// Access how many crew members this ship has or needs.
 	int Crew() const;
+	int TotalCrew() const;
 	int RequiredCrew() const;
-	void AddCrew(int count);
+	void AddCrew(int count, bool addTotal = true);
 	// Check if this is a ship that can be used as a flagship.
 	bool CanBeFlagship() const;
 	
@@ -460,6 +461,7 @@ private:
 	Point acceleration;
 	
 	int crew = 0;
+	int totalCrew = 0;
 	int pilotError = 0;
 	int pilotOkay = 0;
 	


### PR DESCRIPTION
This will decrease the player's reputation by the total crew of a captured ship, rather than its required crew